### PR TITLE
fix: include style in NanoBanana hash key (post-merge codex finding)

### DIFF
--- a/scripts/providers/nanobanana.py
+++ b/scripts/providers/nanobanana.py
@@ -30,7 +30,8 @@ class NanoBananaProvider(ImageProvider):
     def fetch(self, source: dict[str, Any], out_dir: Path) -> Path | None:
         query = source.get("query", "")
         aspect = source.get("aspect", "16:9")
-        slug = hashlib.md5(f"{query}|{aspect}".encode()).hexdigest()[:12]
+        style = source.get("style", "")
+        slug = hashlib.md5(f"{query}|{aspect}|{style}".encode()).hexdigest()[:12]
 
         try:
             import google.generativeai as genai  # type: ignore[import-untyped]


### PR DESCRIPTION
## Summary

Codex post-merge review on PR #6 found that `source.style` was omitted
from the request identity hash in the NanoBanana provider.

Two card-image entries differing only by `style` would produce the same
hash → second write overwrites the first → wrong asset silently attached.

Fix: include `style` in the hash key: `query|aspect|style`.

## Verification
```
ruff check .  ✅
mypy          ✅
pytest -q     ✅ 51 passed
```

## Related
Post-merge finding from PR #6 codex review thread.