### PR TITLE
fix: 3 V1 rendering bugs — stat truncation, quote line-break, card-text overflow

### DIFF
--- a/examples/dify-intro/slides/05-major-minor-demo.svg
+++ b/examples/dify-intro/slides/05-major-minor-demo.svg
@@ -57,7 +57,7 @@
        viewBox="0 0 584 498">
     <rect x="0" y="0" width="6" height="388" rx="3" fill="url(#accent-grad-v)"/>
 
-<text x="32" y="181" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">AI 应用的瓶颈不是模型</text><text x="32" y="236" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">，而是工程化。</text><rect x="32" y="408" width="48" height="3" fill="url(#accent-grad)" rx="2"/>
+<text x="32" y="181" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">AI 应用的瓶颈不是模型，</text><text x="32" y="236" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">而是工程化。</text><rect x="32" y="408" width="48" height="3" fill="url(#accent-grad)" rx="2"/>
 <text x="32" y="448" class="h4">Dify 创始团队</text><text x="32" y="476" class="body" fill="#9BA0B0">2024 年技术分享会</text>
   </svg>
 </g><g transform="translate(56, 56)">

--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -466,7 +466,7 @@ class NativeRenderer:
                 letter_spacing=300,
             )
 
-        # 主数字
+        # 主数字：窄卡设 word_wrap=True 防止截断（如 "<200" 在 152px 宽卡内）
         y += 28 + huge
         self._add_textbox(
             slide,
@@ -478,7 +478,7 @@ class NativeRenderer:
             font_size=huge,
             color=self.theme["colors"]["text_primary"],
             bold=True,
-            word_wrap=False,
+            word_wrap=(W < 300),
         )
 
         unit = data.get("unit")
@@ -1071,11 +1071,12 @@ class NativeRenderer:
         # 段落：合并成一个 textbox 多 paragraph，PowerPoint 自动换行
         paragraphs = data.get("paragraphs") or []
         if paragraphs:
+            para_h = max(H - y - 8, 64)  # 窄卡保底 64px 防截断
             tb = slide.shapes.add_textbox(
                 self._x(inner["x"]),
                 self._y(inner["y"] + y),
                 self._x(W),
-                self._y(H - y - 8),
+                self._y(para_h),
             )
             tf = tb.text_frame
             tf.margin_left = tf.margin_right = 0

--- a/themes/bento-tech/components/card-quote.svg.j2
+++ b/themes/bento-tech/components/card-quote.svg.j2
@@ -20,10 +20,10 @@
 {# 横幅模式：右侧给 author 留 280px，quote 占左侧剩余宽度 #}
 {%- set author_block_w = 300 if (d.author or d.role) else 0 -%}
 {%- set q_max_w = W - 32 - author_block_w - 24 -%}
-{%- set chars_per_line = (q_max_w / unit_w) | int -%}
+{%- set chars_per_line = (q_max_w / unit_w * 1.1) | int -%}
 {%- else -%}
-{# 大卡模式：quote 占满宽度（除去左侧竖条 + 32px gutter）#}
-{%- set chars_per_line = ((W - 48) / unit_w) | int -%}
+{# 大卡模式：quote 占满宽度（除去左侧竖条 + 32px gutter）；1.1x 余量防 CJK 词组拆分 #}
+{%- set chars_per_line = ((W - 48) / unit_w * 1.1) | int -%}
 {%- endif -%}
 
 {%- set line_h = (q_size * 1.25) | int -%}


### PR DESCRIPTION
## Summary

Fix 3 known V1 rendering bugs documented in `examples/dify-intro/README.md`:

1. **stat value truncation** (`<200` → `<20`): `word_wrap=False` on narrow cards
   caused PowerPoint to clip text at textbox boundary → use `word_wrap=True` when W<300
2. **card-quote bad line-break**: CJK char-width estimator split compound words
   ("模型" → "模" + "型") → 1.1x chars_per_line headroom
3. **card-text overflow**: narrow-card paragraph textbox <64px tall
   → 64px minimum height guard

## Verification
```
ruff check    ✅
ruff format   ✅  
mypy          ✅
pytest -q     ✅ 51 passed
```

## Related
Closes #8