### PR TITLE
chore: 测试覆盖率 54%→60% — card-compare/stack/quote/render 错误路径

### DIFF
--- a/tests/test_native_render.py
+++ b/tests/test_native_render.py
@@ -92,3 +92,90 @@ class TestNativeDeckRender:
             assert result.stat().st_size > 1000
         finally:
             out.unlink(missing_ok=True)
+
+
+class TestNativeDeckIntegration:
+    """Integration tests that render full decks to exercise component code paths."""
+
+    def test_deck_with_card_compare(self):
+        """Exercise card-compare via a minimal deck render."""
+        layout = {
+            "theme": "bento-tech",
+            "meta": {"title": "test"},
+            "pages": [
+                {
+                    "page": 1,
+                    "layout": "two-col-symmetric",
+                    "cards": [
+                        {
+                            "slot": "left",
+                            "component": "card-compare",
+                            "data": {
+                                "headers": ["基础版", "专业版"],
+                                "recommend": 1,
+                                "rows": [
+                                    {"label": "价格", "values": ["免费", "999/月"]},
+                                    {"label": "并发", "values": ["100", "1000"], "highlight": True},
+                                ],
+                            },
+                        },
+                        {
+                            "slot": "right",
+                            "component": "card-stack",
+                            "data": {
+                                "label": "指标",
+                                "primary": {"value": "187", "unit": "ms", "suffix": "响应"},
+                                "secondary": [{"label": "99分位", "value": "420 ms"}],
+                                "progress": {"percent": 95, "label": "完成"},
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as f:
+            out = Path(f.name)
+        try:
+            nr = NativeRenderer("bento-tech")
+            nr.render_deck(layout, out)
+            assert out.stat().st_size > 1000
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_deck_with_quote_and_text(self):
+        """Exercise card-quote and card-text via a minimal deck."""
+        layout = {
+            "theme": "bento-tech",
+            "meta": {"title": "test"},
+            "pages": [
+                {
+                    "page": 1,
+                    "layout": "two-col-symmetric",
+                    "cards": [
+                        {
+                            "slot": "left",
+                            "component": "card-quote",
+                            "data": {"quote": "少即是多。", "author": "Author", "role": "Role"},
+                        },
+                        {
+                            "slot": "right",
+                            "component": "card-text",
+                            "data": {
+                                "eyebrow": "OVERVIEW",
+                                "title": "标题",
+                                "badges": ["标签A", {"text": "警告", "variant": "warning"}],
+                                "paragraphs": ["第一段文字内容。", "第二段文字内容。"],
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as f:
+            out = Path(f.name)
+        try:
+            nr = NativeRenderer("bento-tech")
+            nr.render_deck(layout, out)
+            assert out.stat().st_size > 1000
+        finally:
+            out.unlink(missing_ok=True)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -129,3 +129,38 @@ class TestThemeColorContrast:
 
         svg = render_card(env, manifest, card, slot_w=500, slot_h=400)
         assert 'fill="#0a0e27"' in svg
+
+
+class TestRenderCardEdgeCases:
+    def test_render_card_no_component(self):
+        manifest, env = load_theme("bento-tech")
+        from render import render_card
+
+        result = render_card(env, manifest, {"data": {}}, slot_w=500, slot_h=500)
+        assert result == ""
+
+    def test_render_card_missing_template(self):
+        manifest, env = load_theme("bento-tech")
+        import pytest
+        from render import render_card
+
+        with pytest.raises(SystemExit):
+            render_card(env, manifest, {"component": "nonexistent-component"}, slot_w=500, slot_h=500)
+
+
+class TestRenderOnePageErrors:
+    def test_missing_layout_field(self):
+        manifest, env = load_theme("bento-tech")
+        import pytest
+        from render import render_one_page
+
+        with pytest.raises(SystemExit):
+            render_one_page(env, manifest, {"page": 1}, total_pages=1, meta={})
+
+    def test_invalid_layout_name(self):
+        manifest, env = load_theme("bento-tech")
+        import pytest
+        from render import render_one_page
+
+        with pytest.raises(SystemExit):
+            render_one_page(env, manifest, {"page": 1, "layout": "nonexistent-layout"}, total_pages=1, meta={})


### PR DESCRIPTION
integration tests for card-compare, card-stack, card-quote, card-text + render.py error paths. 57 tests, 60% coverage (native_render 81%, render 93%). Closes #10