### PR TITLE
feat: bento-paper 主题 — 杂志风 × 纸质印刷美学

### DIFF
--- a/examples/dify-intro/slides/01-cover.svg
+++ b/examples/dify-intro/slides/01-cover.svg
@@ -4,64 +4,64 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e27"/>
-      <stop offset="100%" stop-color="#1a1f3a"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#7c5cff"/>
-      <stop offset="100%" stop-color="#00d4ff"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#7c5cff"/>
-      <stop offset="100%" stop-color="#00d4ff"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#7c5cff" stop-opacity="0.4"/>
-      <stop offset="100%" stop-color="#7c5cff" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0.3"/>
-      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="0.5"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #00d4ff; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #ffffff; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #ffffff; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #ffffff; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #ffffff; font-weight: 600; }
-    .body { font-size: 18px; fill: #bcc4d8; }
-    .small { font-size: 14px; fill: #6b7392; }
-    .stat-huge { font-size: 110px; fill: #ffffff; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #bcc4d8; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="1168" height="578"
-        rx="20"
-        fill="#ffffff" fill-opacity="0.06"
-        stroke="#ffffff" stroke-opacity="0.12"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="1088" height="498"
        viewBox="0 0 1088 498">
-    <text x="1068" y="482" text-anchor="end" font-size="159" font-weight="900" fill="#7c5cff" opacity="0.07" letter-spacing="6" font-family="&#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif">2026 FUTURE</text><text x="0" y="20" class="eyebrow">PRODUCT INTRO · 2026 Q2</text><text x="0" y="98" font-size="60" fill="#ffffff" font-weight="700">Dify 企业介绍</text><text x="0" y="170" font-size="60" fill="#ffffff" font-weight="700">下一代 AI 应用开发平台</text><g transform="translate(0, 192)">
-  <rect x="0" y="0" width="130" height="22" rx="11" fill="#7c5cff" fill-opacity="0.22" stroke="#7c5cff" stroke-opacity="0.55" stroke-width="1"/>
+    <text x="1068" y="482" text-anchor="end" font-size="159" font-weight="900" fill="#8B5E3C" opacity="0.07" letter-spacing="6" font-family="&#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif">2026 FUTURE</text><text x="0" y="18" class="eyebrow">PRODUCT INTRO · 2026 Q2</text><text x="0" y="92" font-size="56" fill="#1a1815" font-weight="700">Dify 企业介绍</text><text x="0" y="159" font-size="56" fill="#1a1815" font-weight="700">下一代 AI 应用开发平台</text><g transform="translate(0, 181)">
+  <rect x="0" y="0" width="130" height="22" rx="11" fill="#8B5E3C" fill-opacity="0.22" stroke="#8B5E3C" stroke-opacity="0.55" stroke-width="1"/>
   <text x="65.0" y="15" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff" letter-spacing="0.5">PRODUCTION-READY</text>
-</g><text x="0" y="254" font-size="30" fill="#bcc4d8" font-weight="400">把生成式 AI 的不确定，变成产品落地的确定</text><rect x="0" y="418" width="120" height="4" fill="url(#accent-grad)" rx="2"/><text x="0" y="460" font-size="12" fill="#6b7392" letter-spacing="2">PRESENTED BY</text>
-<text x="0" y="486" font-size="18" fill="#ffffff" font-weight="600">Dify Team</text><text x="362" y="460" font-size="12" fill="#6b7392" letter-spacing="2">DATE</text>
-<text x="362" y="486" font-size="18" fill="#ffffff" font-weight="600">2026 Q2</text><text x="724" y="460" font-size="12" fill="#6b7392" letter-spacing="2">AUDIENCE</text>
-<text x="724" y="486" font-size="18" fill="#ffffff" font-weight="600">企业客户 / 投资人</text>
+</g><text x="0" y="241" font-size="28" fill="#5c5548" font-weight="400">把生成式 AI 的不确定，变成产品落地的确定</text><rect x="0" y="418" width="120" height="4" fill="url(#accent-grad)" rx="2"/><text x="0" y="460" font-size="12" fill="#9c9588" letter-spacing="2">PRESENTED BY</text>
+<text x="0" y="486" font-size="18" fill="#1a1815" font-weight="600">Dify Team</text><text x="362" y="460" font-size="12" fill="#9c9588" letter-spacing="2">DATE</text>
+<text x="362" y="486" font-size="18" fill="#1a1815" font-weight="600">2026 Q2</text><text x="724" y="460" font-size="12" fill="#9c9588" letter-spacing="2">AUDIENCE</text>
+<text x="724" y="486" font-size="18" fill="#1a1815" font-weight="600">企业客户 / 投资人</text>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/02-two-col-symmetric-demo.svg
+++ b/examples/dify-intro/slides/02-two-col-symmetric-demo.svg
@@ -4,69 +4,69 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="574" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="494" height="498"
        viewBox="0 0 494 498">
-    <text x="0" y="20" class="eyebrow">全球开发者</text><text x="0" y="158" font-size="110" fill="#0F0F10" font-weight="800">180</text><text x="188" y="158" font-size="30" fill="#555666" font-weight="500">万+</text><text x="0" y="196" font-size="22" fill="#0d9e5e" font-weight="600">↑ 180% YoY</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="14" fill="#555666">覆盖 130+ 个国家与地区</text>
+    <text x="0" y="18" class="eyebrow">全球开发者</text><text x="0" y="146" font-size="100" fill="#1a1815" font-weight="800">180</text><text x="173" y="146" font-size="28" fill="#5c5548" font-weight="500">万+</text><text x="0" y="184" font-size="22" fill="#4a7c59" font-weight="600">↑ 180% YoY</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="13" fill="#5c5548">覆盖 130+ 个国家与地区</text>
   </svg>
 </g><g transform="translate(650, 56)">
   <rect x="0" y="0" width="574" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="494" height="498"
        viewBox="0 0 494 498">
-    <text x="0" y="20" class="eyebrow">企业客户</text><text x="0" y="158" font-size="110" fill="#0F0F10" font-weight="800">12000</text><text x="308" y="158" font-size="30" fill="#555666" font-weight="500">+</text><text x="0" y="196" font-size="22" fill="#0d9e5e" font-weight="600">↑ Fortune 500 中的 23 家</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="14" fill="#555666">金融、零售、教育、政务皆有落地</text>
+    <text x="0" y="18" class="eyebrow">企业客户</text><text x="0" y="146" font-size="100" fill="#1a1815" font-weight="800">12000</text><text x="283" y="146" font-size="28" fill="#5c5548" font-weight="500">+</text><text x="0" y="184" font-size="22" fill="#4a7c59" font-weight="600">↑ Fortune 500 中的 23 家</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="13" fill="#5c5548">金融、零售、教育、政务皆有落地</text>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/03-two-col-asymmetric-demo.svg
+++ b/examples/dify-intro/slides/03-two-col-asymmetric-demo.svg
@@ -4,77 +4,77 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="776" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="696" height="498"
        viewBox="0 0 696 498">
-    <text x="0" y="20" class="eyebrow">为什么选择 Dify</text><text x="0" y="76" class="h3">把模型能力和业务流程缝起来</text><text x="0" y="120" font-size="18" fill="#555666">Dify 不是又一个聊天机器人，而是把 LLM 能力变成稳定可交付的业务流程。从 prom</text><text x="0" y="148" font-size="18" fill="#555666">pt 编排到工具调用、从知识库到日志评测，全链路可观测、可回滚。</text><text x="0" y="186" font-size="18" fill="#555666">工程团队不需要重复造轮子。市场团队不需要等着 IT 排期。运维团队不需要担心 to</text><text x="0" y="214" font-size="18" fill="#555666">ken 失控。</text>
+    <text x="0" y="18" class="eyebrow">为什么选择 Dify</text><text x="0" y="72" class="h3">把模型能力和业务流程缝起来</text><text x="0" y="115" font-size="17" fill="#5c5548">Dify 不是又一个聊天机器人，而是把 LLM 能力变成稳定可交付的业务流程。从 prompt 编排到</text><text x="0" y="142" font-size="17" fill="#5c5548">工具调用、从知识库到日志评测，全链路可观测、可回滚。</text><text x="0" y="179" font-size="17" fill="#5c5548">工程团队不需要重复造轮子。市场团队不需要等着 IT 排期。运维团队不需要担心 token 失控。</text>
   </svg>
 </g><g transform="translate(852, 56)">
   <rect x="0" y="0" width="372" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="292" height="498"
        viewBox="0 0 292 498">
-    <text x="0" y="48" class="h3">核心模块</text><g transform="translate(0, 76)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+    <text x="0" y="46" class="h3">核心模块</text><g transform="translate(0, 74)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">01</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="600">Workflow</text>  <text x="48" y="46" font-size="14" fill="#555666">可视化编排</text></g><g transform="translate(0, 156)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="600">Workflow</text>  <text x="48" y="46" font-size="14" fill="#5c5548">可视化编排</text></g><g transform="translate(0, 154)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">02</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="600">Agent</text>  <text x="48" y="46" font-size="14" fill="#555666">工具调用框架</text></g><g transform="translate(0, 236)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="600">Agent</text>  <text x="48" y="46" font-size="14" fill="#5c5548">工具调用框架</text></g><g transform="translate(0, 234)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">03</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="600">Knowledge</text>  <text x="48" y="46" font-size="14" fill="#555666">RAG 引擎</text></g><g transform="translate(0, 316)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="600">Knowledge</text>  <text x="48" y="46" font-size="14" fill="#5c5548">RAG 引擎</text></g><g transform="translate(0, 314)" opacity="1.0">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">04</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="600">LLMOps</text>  <text x="48" y="46" font-size="14" fill="#555666">评测与监控</text></g>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="600">LLMOps</text>  <text x="48" y="46" font-size="14" fill="#5c5548">评测与监控</text></g>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/04-three-col-demo.svg
+++ b/examples/dify-intro/slides/04-three-col-demo.svg
@@ -4,80 +4,80 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="376" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="498"
        viewBox="0 0 296 498">
-    <text x="0" y="20" class="eyebrow">搭建一个 AI 应用</text><text x="0" y="136" font-size="88" fill="#0F0F10" font-weight="800">5</text><text x="56" y="136" font-size="24" fill="#555666" font-weight="500">分钟</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="14" fill="#555666">从模板到上线</text>
+    <text x="0" y="18" class="eyebrow">搭建一个 AI 应用</text><text x="0" y="134" font-size="88" fill="#1a1815" font-weight="800">5</text><text x="56" y="134" font-size="24" fill="#5c5548" font-weight="500">分钟</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="13" fill="#5c5548">从模板到上线</text>
   </svg>
 </g><g transform="translate(452, 56)">
   <rect x="0" y="0" width="376" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="498"
        viewBox="0 0 296 498">
-    <text x="0" y="20" class="eyebrow">支持模型数</text><text x="0" y="136" font-size="88" fill="#0F0F10" font-weight="800">200</text><text x="152" y="136" font-size="24" fill="#555666" font-weight="500">+</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="14" fill="#555666">OpenAI / Anthropic / 国产</text>
+    <text x="0" y="18" class="eyebrow">支持模型数</text><text x="0" y="134" font-size="88" fill="#1a1815" font-weight="800">200</text><text x="152" y="134" font-size="24" fill="#5c5548" font-weight="500">+</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="13" fill="#5c5548">OpenAI / Anthropic / 国产</text>
   </svg>
 </g><g transform="translate(848, 56)">
   <rect x="0" y="0" width="376" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="498"
        viewBox="0 0 296 498">
-    <text x="0" y="20" class="eyebrow">可观测性</text><text x="0" y="136" font-size="88" fill="#0F0F10" font-weight="800">100</text><text x="152" y="136" font-size="24" fill="#555666" font-weight="500">%</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="14" fill="#555666">全链路日志与评测</text>
+    <text x="0" y="18" class="eyebrow">可观测性</text><text x="0" y="134" font-size="88" fill="#1a1815" font-weight="800">100</text><text x="152" y="134" font-size="24" fill="#5c5548" font-weight="500">%</text><rect x="0" y="434" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="466" font-size="13" fill="#5c5548">全链路日志与评测</text>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/05-major-minor-demo.svg
+++ b/examples/dify-intro/slides/05-major-minor-demo.svg
@@ -4,105 +4,105 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(308, 56)">
   <rect x="0" y="0" width="664" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="584" height="498"
        viewBox="0 0 584 498">
     <rect x="0" y="0" width="6" height="388" rx="3" fill="url(#accent-grad-v)"/>
 
-<text x="32" y="181" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">AI 应用的瓶颈不是模型，</text><text x="32" y="236" font-size="44" fill="#0F0F10" font-weight="500" font-style="italic">而是工程化。</text><rect x="32" y="408" width="48" height="3" fill="url(#accent-grad)" rx="2"/>
-<text x="32" y="448" class="h4">Dify 创始团队</text><text x="32" y="476" class="body" fill="#9BA0B0">2024 年技术分享会</text>
+<text x="32" y="183" font-size="42" fill="#1a1815" font-weight="500" font-style="italic">AI 应用的瓶颈不是模型，而</text><text x="32" y="235" font-size="42" fill="#1a1815" font-weight="500" font-style="italic">是工程化。</text><rect x="32" y="408" width="48" height="3" fill="url(#accent-grad)" rx="2"/>
+<text x="32" y="448" class="h4">Dify 创始团队</text><text x="32" y="476" class="body" fill="#9c9588">2024 年技术分享会</text>
   </svg>
 </g><g transform="translate(56, 56)">
   <rect x="0" y="0" width="232" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="152" height="200"
        viewBox="0 0 152 200">
-    <text x="0" y="20" class="eyebrow">模型延迟</text><text x="0" y="112" font-size="64" fill="#0F0F10" font-weight="800">&lt;200</text><text x="0" y="133" font-size="17" fill="#555666" font-weight="500">ms</text><rect x="0" y="157" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
+    <text x="0" y="18" class="eyebrow">模型延迟</text><text x="0" y="110" font-size="64" fill="#1a1815" font-weight="800">&lt;200</text><text x="0" y="131" font-size="17" fill="#5c5548" font-weight="500">ms</text><rect x="0" y="155" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
   </svg>
 </g><g transform="translate(56, 354)">
   <rect x="0" y="0" width="232" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="152" height="200"
        viewBox="0 0 152 200">
-    <text x="0" y="20" class="eyebrow">成本下降</text><text x="0" y="112" font-size="64" fill="#0F0F10" font-weight="800">60</text><text x="78" y="112" font-size="17" fill="#555666" font-weight="500">%</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
+    <text x="0" y="18" class="eyebrow">成本下降</text><text x="0" y="110" font-size="64" fill="#1a1815" font-weight="800">60</text><text x="78" y="110" font-size="17" fill="#5c5548" font-weight="500">%</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
   </svg>
 </g><g transform="translate(992, 56)">
   <rect x="0" y="0" width="232" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="152" height="200"
        viewBox="0 0 152 200">
-    <text x="0" y="20" class="eyebrow">上线周期</text><text x="0" y="112" font-size="64" fill="#0F0F10" font-weight="800">1/10</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="168" font-size="14" fill="#555666">对比传统开发</text>
+    <text x="0" y="18" class="eyebrow">上线周期</text><text x="0" y="110" font-size="64" fill="#1a1815" font-weight="800">1/10</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/><text x="0" y="168" font-size="13" fill="#5c5548">对比传统开发</text>
   </svg>
 </g><g transform="translate(992, 354)">
   <rect x="0" y="0" width="232" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="152" height="200"
        viewBox="0 0 152 200">
-    <text x="0" y="20" class="eyebrow">客户留存</text><text x="0" y="112" font-size="64" fill="#0F0F10" font-weight="800">94</text><text x="78" y="112" font-size="17" fill="#555666" font-weight="500">%</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
+    <text x="0" y="18" class="eyebrow">客户留存</text><text x="0" y="110" font-size="64" fill="#1a1815" font-weight="800">94</text><text x="78" y="110" font-size="17" fill="#5c5548" font-weight="500">%</text><rect x="0" y="136" width="60" height="3" fill="url(#accent-grad)" rx="2"/>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/06-hero-top-demo.svg
+++ b/examples/dify-intro/slides/06-hero-top-demo.svg
@@ -4,109 +4,109 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="1168" height="240"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="1088" height="160"
        viewBox="0 0 1088 160">
-    <text x="0" y="20" class="eyebrow">ARCHITECTURE</text><text x="0" y="82" font-size="44" fill="#0F0F10" font-weight="700">分层架构：从数据层到编排层</text><text x="0" y="122" font-size="22" fill="#555666" font-weight="400">每一层都可独立替换，整体可观测</text>
+    <text x="0" y="18" class="eyebrow">ARCHITECTURE</text><text x="0" y="78" font-size="42" fill="#1a1815" font-weight="700">分层架构：从数据层到编排层</text><text x="0" y="116" font-size="20" fill="#5c5548" font-weight="400">每一层都可独立替换，整体可观测</text>
   </svg>
 </g><g transform="translate(56, 316)">
   <rect x="0" y="0" width="376" height="318"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="238"
        viewBox="0 0 296 238">
-    <text x="0" y="48" class="h3">数据层</text><g transform="translate(0, 76)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+    <text x="0" y="46" class="h3">数据层</text><g transform="translate(0, 74)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">01</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="700">向量库</text></g><g transform="translate(0, 124)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="700">向量库</text></g><g transform="translate(0, 123)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">02</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">对象存储</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">对象存储</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">03</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">审计日志</text></g>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">审计日志</text></g>
   </svg>
 </g><g transform="translate(452, 316)">
   <rect x="0" y="0" width="376" height="318"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="238"
        viewBox="0 0 296 238">
-    <text x="0" y="48" class="h3">能力层</text><g transform="translate(0, 76)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+    <text x="0" y="46" class="h3">能力层</text><g transform="translate(0, 74)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">01</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="700">模型路由</text></g><g transform="translate(0, 124)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="700">模型路由</text></g><g transform="translate(0, 123)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">02</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">工具调用</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">工具调用</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">03</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">知识检索</text></g>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">知识检索</text></g>
   </svg>
 </g><g transform="translate(848, 316)">
   <rect x="0" y="0" width="376" height="318"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="296" height="238"
        viewBox="0 0 296 238">
-    <text x="0" y="48" class="h3">编排层</text><g transform="translate(0, 76)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+    <text x="0" y="46" class="h3">编排层</text><g transform="translate(0, 74)" opacity="1.0"><rect x="-12" y="0" width="4" height="32" rx="2" fill="url(#accent-grad)"/>  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">01</text>
-  <text x="48" y="22" font-size="18" fill="#0F0F10" font-weight="700">Workflow</text></g><g transform="translate(0, 124)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#1a1815" font-weight="700">Workflow</text></g><g transform="translate(0, 123)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">02</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">Agent</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">Agent</text></g><g transform="translate(0, 172)" opacity="0.42">  <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#accent-grad)"/>
   <text x="16" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">03</text>
-  <text x="48" y="22" font-size="18" fill="#555666" font-weight="600">Chat 流</text></g>
+  <text x="48" y="22" font-size="18" fill="#5c5548" font-weight="600">Chat 流</text></g>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/07-mixed-grid-demo.svg
+++ b/examples/dify-intro/slides/07-mixed-grid-demo.svg
@@ -4,53 +4,53 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="776" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="696" height="200"
@@ -60,41 +60,41 @@
   <rect x="180" y="0" width="352" height="22" rx="6"
         fill="#FFFFFF" fill-opacity="0.06"/>
   <rect x="180" y="0" width="352" height="22" rx="6" fill="url(#accent-grad)"/>
-  <text x="544" y="17.0" class="h4" fill="#0F0F10">42 <tspan font-size="14" fill="#9BA0B0">亿</tspan></text>
+  <text x="544" y="17.0" class="h4" fill="#1a1815">42 <tspan font-size="14" fill="#9c9588">亿</tspan></text>
 </g><g transform="translate(0, 96)">
   <text x="0" y="17.0" class="body" font-weight="500">Claude</text>
   <rect x="180" y="0" width="352" height="22" rx="6"
         fill="#FFFFFF" fill-opacity="0.06"/>
   <rect x="180" y="0" width="259" height="22" rx="6" fill="url(#accent-grad)"/>
-  <text x="451" y="17.0" class="h4" fill="#0F0F10">31 <tspan font-size="14" fill="#9BA0B0">亿</tspan></text>
+  <text x="451" y="17.0" class="h4" fill="#1a1815">31 <tspan font-size="14" fill="#9c9588">亿</tspan></text>
 </g><g transform="translate(0, 136)">
   <text x="0" y="17.0" class="body" font-weight="500">Gemini</text>
   <rect x="180" y="0" width="352" height="22" rx="6"
         fill="#FFFFFF" fill-opacity="0.06"/>
   <rect x="180" y="0" width="150" height="22" rx="6" fill="url(#accent-grad)"/>
-  <text x="342" y="17.0" class="h4" fill="#0F0F10">18 <tspan font-size="14" fill="#9BA0B0">亿</tspan></text>
+  <text x="342" y="17.0" class="h4" fill="#1a1815">18 <tspan font-size="14" fill="#9c9588">亿</tspan></text>
 </g>
   </svg>
 </g><g transform="translate(852, 56)">
   <rect x="0" y="0" width="372" height="280"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="292" height="200"
        viewBox="0 0 292 200">
-    <text x="0" y="20" class="eyebrow">运行指标</text>
-<text x="0" y="85" font-size="48" fill="#0F0F10" font-weight="800">187</text><text x="86" y="85" font-size="14" fill="#0066bb" font-weight="600">ms</text><text x="114" y="81" font-size="18" fill="#555666">API 平均响应</text><text x="0" y="101" font-size="12" fill="#9BA0B0" letter-spacing="1">99 分位</text>
-<text x="0" y="119" font-size="18" fill="#0F0F10" font-weight="700">420 ms</text><text x="146" y="101" font-size="12" fill="#9BA0B0" letter-spacing="1">错误率</text>
-<text x="146" y="119" font-size="18" fill="#0F0F10" font-weight="700">0.03%</text><rect x="0" y="140" width="292" height="6" rx="3" fill="#FFFFFF" fill-opacity="0.10"/>
-<rect x="0" y="140" width="289" height="6" rx="3" fill="url(#accent-grad)"/><text x="0" y="168" font-size="14" fill="#555666">SLA 99% 达标</text>
+    <text x="0" y="18" class="eyebrow">运行指标</text>
+<text x="0" y="84" font-size="48" fill="#1a1815" font-weight="800">187</text><text x="86" y="84" font-size="14" fill="#4a7c6b" font-weight="600">ms</text><text x="114" y="80" font-size="17" fill="#5c5548">API 平均响应</text><text x="0" y="100" font-size="12" fill="#9c9588" letter-spacing="1">99 分位</text>
+<text x="0" y="118" font-size="18" fill="#1a1815" font-weight="700">420 ms</text><text x="146" y="100" font-size="12" fill="#9c9588" letter-spacing="1">错误率</text>
+<text x="146" y="118" font-size="18" fill="#1a1815" font-weight="700">0.03%</text><rect x="0" y="140" width="292" height="6" rx="3" fill="#FFFFFF" fill-opacity="0.10"/>
+<rect x="0" y="140" width="289" height="6" rx="3" fill="url(#accent-grad)"/><text x="0" y="168" font-size="13" fill="#5c5548">SLA 99% 达标</text>
   </svg>
 </g><g transform="translate(56, 356)">
   <rect x="0" y="0" width="372" height="278"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="292" height="198"
@@ -103,14 +103,14 @@
   </svg>
 </g><g transform="translate(452, 356)">
   <rect x="0" y="0" width="772" height="278"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="692" height="198"
        viewBox="0 0 692 198">
-    <text x="0" y="38" class="h3">落地案例</text><text x="0" y="82" font-size="18" fill="#555666">某头部券商：用 Dify 把 17 个内部系统的接口能力封装成 Agent 工具，把客户经理</text><text x="0" y="110" font-size="18" fill="#555666">日均处理工单数从 23 提升到 78。</text><text x="0" y="148" font-size="18" fill="#555666">某省级政务平台：基于 Dify 知识库构建公文助手，问答准确率从 62% 提升到 91%。</text>
+    <text x="0" y="36" class="h3">落地案例</text><text x="0" y="79" font-size="17" fill="#5c5548">某头部券商：用 Dify 把 17 个内部系统的接口能力封装成 Agent 工具，把客户经理日均处理</text><text x="0" y="106" font-size="17" fill="#5c5548">工单数从 23 提升到 78。</text><text x="0" y="143" font-size="17" fill="#5c5548">某省级政务平台：基于 Dify 知识库构建公文助手，问答准确率从 62% 提升到 91%。</text>
   </svg>
 </g>
 

--- a/examples/dify-intro/slides/08-end.svg
+++ b/examples/dify-intro/slides/08-end.svg
@@ -4,58 +4,58 @@
      width="1280" height="720">
   <defs>
     <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#F6F3EE"/>
-      <stop offset="100%" stop-color="#EDE9E2"/>
+      <stop offset="0%" stop-color="#F5F0E8"/>
+      <stop offset="100%" stop-color="#EDE6D8"/>
     </linearGradient>
     <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient>
     <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#6644ee"/>
-      <stop offset="100%" stop-color="#0066bb"/>
+      <stop offset="0%" stop-color="#8B5E3C"/>
+      <stop offset="100%" stop-color="#4a7c6b"/>
     </linearGradient><radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#6644ee" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#6644ee" stop-opacity="0"/>
+      <stop offset="0%" stop-color="#8B5E3C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#8B5E3C" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#0066bb" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0066bb" stop-opacity="0"/>
-    </radialGradient>    <pattern id="bg-texture" width="32" height="32" patternUnits="userSpaceOnUse">
-      <circle cx="16" cy="16" r="0.9" fill="#1a1a2e" fill-opacity="0.12"/>
+      <stop offset="0%" stop-color="#4a7c6b" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#4a7c6b" stop-opacity="0"/>
+    </radialGradient>    <pattern id="bg-texture" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.9" fill="#1a1815" fill-opacity="0.06"/>
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, &#39;SF Pro Display&#39;, &#39;Inter&#39;, sans-serif; }
-    .mono { font-family: &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
-    .eyebrow { font-size: 16px; fill: #0066bb; letter-spacing: 3px; font-weight: 600; }
-    .h1 { font-size: 60px; fill: #0F0F10; font-weight: 700; }
-    .h2 { font-size: 44px; fill: #0F0F10; font-weight: 700; }
-    .h3 { font-size: 30px; fill: #0F0F10; font-weight: 600; }
-    .h4 { font-size: 22px; fill: #0F0F10; font-weight: 600; }
-    .body { font-size: 18px; fill: #555666; }
-    .small { font-size: 14px; fill: #9BA0B0; }
-    .stat-huge { font-size: 110px; fill: #0F0F10; font-weight: 800; }
-    .stat-unit { font-size: 28px; fill: #555666; font-weight: 500; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #4a7c6b; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .body { font-size: 17px; fill: #5c5548; }
+    .small { font-size: 13px; fill: #9c9588; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
   <!-- 背景渐变 -->
-  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层（在渐变之上、装饰光斑之下）-->
+  <rect width="1280" height="720" fill="url(#bg-grad)"/>  <!-- 纹理层 -->
   <rect width="1280" height="720" fill="url(#bg-texture)"/>
-  <!-- 装饰光斑（不影响内容可读性） -->
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
   <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
   <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
   <!-- layout 渲染区 -->
   <g transform="translate(56, 56)">
   <rect x="0" y="0" width="1168" height="578"
-        rx="20"
-        fill="#FFFFFF" fill-opacity="0.75"
-        stroke="#1a1a2e" stroke-opacity="0.09"
+        rx="16"
+        fill="#FFFFFF" fill-opacity="0.82"
+        stroke="#1a1815" stroke-opacity="0.07"
         stroke-width="1"/>
   <svg x="40" y="40"
        width="1088" height="498"
        viewBox="0 0 1088 498">
-    <text x="0" y="20" class="eyebrow">THANK YOU</text><text x="0" y="98" font-size="60" fill="#0F0F10" font-weight="700">让我们一起，把 AI 装进每一个业务流程</text><text x="0" y="146" font-size="30" fill="#555666" font-weight="400">联系 sales@dify.ai 安排技术演示</text><rect x="0" y="418" width="120" height="4" fill="url(#accent-grad)" rx="2"/><text x="0" y="474" class="body">Dify · 2026</text>
+    <text x="0" y="18" class="eyebrow">THANK YOU</text><text x="0" y="92" font-size="56" fill="#1a1815" font-weight="700">让我们一起，把 AI 装进每一个业务流程</text><text x="0" y="138" font-size="28" fill="#5c5548" font-weight="400">联系 sales@dify.ai 安排技术演示</text><rect x="0" y="418" width="120" height="4" fill="url(#accent-grad)" rx="2"/><text x="0" y="474" class="body">Dify · 2026</text>
   </svg>
 </g>
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -164,3 +164,33 @@ class TestRenderOnePageErrors:
 
         with pytest.raises(SystemExit):
             render_one_page(env, manifest, {"page": 1, "layout": "nonexistent-layout"}, total_pages=1, meta={})
+
+
+class TestBentoPaper:
+    def test_load_theme(self):
+        manifest, _ = load_theme("bento-paper")
+        assert manifest["name"] == "bento-paper"
+        assert manifest["effects"]["bg_texture"] == "dots"
+        assert "Noto Serif SC" in manifest["fonts"]["display"]
+
+    def test_render_example(self):
+        ws = Path("examples/dify-intro")
+        result = render_all(ws, theme="bento-paper")
+        assert result["rendered"] == 8
+        assert result["theme"] == "bento-paper"
+
+    def test_font_hierarchy_in_svg(self):
+        """Verify serif headings + sans body + mono eyebrow in rendered output."""
+        manifest, env = load_theme("bento-paper")
+        from render import render_one_page
+
+        page = {
+            "page": 1,
+            "layout": "single-focus",
+            "cards": [{"slot": "main", "component": "card-hero", "data": {"eyebrow": "MAGAZINE", "title": "标题", "subtitle": "副标题"}}],
+        }
+        svg = render_one_page(env, manifest, page, total_pages=1, meta={})
+        assert "Noto Serif SC" in svg
+        assert "IBM Plex Mono" in svg
+        assert "#F5F0E8" in svg
+        assert "#8B5E3C" in svg

--- a/themes/bento-paper/manifest.json
+++ b/themes/bento-paper/manifest.json
@@ -1,0 +1,121 @@
+{
+  "name": "bento-paper",
+  "version": "1.0.0",
+  "description": "电子杂志 × 纸质印刷美学 — 衬线标题 + 非衬线正文 + 等宽元数据，温暖的书籍质感",
+  "viewBox": {
+    "width": 1280,
+    "height": 720
+  },
+  "fonts": {
+    "sans": "'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif",
+    "mono": "'IBM Plex Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace",
+    "display": "'Noto Serif SC', 'Playfair Display', 'Times New Roman', serif"
+  },
+  "type_scale": {
+    "eyebrow": 14,
+    "h1": 56,
+    "h2": 42,
+    "h3": 28,
+    "h4": 20,
+    "body": 17,
+    "small": 13,
+    "stat_huge": 100,
+    "stat_unit": 26
+  },
+  "colors": {
+    "bg_start": "#F5F0E8",
+    "bg_end": "#EDE6D8",
+    "card_fill": "#FFFFFF",
+    "card_fill_opacity": 0.82,
+    "card_stroke": "#1a1815",
+    "card_stroke_opacity": 0.07,
+    "text_primary": "#1a1815",
+    "text_secondary": "#5c5548",
+    "text_muted": "#9c9588",
+    "accent_primary": "#8B5E3C",
+    "accent_secondary": "#4a7c6b",
+    "accent_tertiary": "#c44d34",
+    "accent_success": "#4a7c59",
+    "accent_warning": "#c47d00"
+  },
+  "spacing": {
+    "page_padding": 56,
+    "footer_height": 30,
+    "card_padding": 40,
+    "card_gap": 20,
+    "card_radius": 16,
+    "card_stroke_width": 1
+  },
+  "effects": {
+    "bg_texture": "dots",
+    "bg_texture_opacity": 0.03,
+    "bg_texture_size": 24,
+    "bg_texture_color": "#1a1815",
+    "bg_spot_opacity": 0.08
+  },
+  "layouts": {
+    "single-focus": {
+      "card_count": 1,
+      "description": "1 张大卡片占满，适合金句/核心数字/封面",
+      "slots": {
+        "main": { "x": 56, "y": 56, "w": 1168, "h": 578 }
+      }
+    },
+    "two-col-symmetric": {
+      "card_count": 2,
+      "description": "2 张等宽，适合对比/并列两个概念",
+      "slots": {
+        "left":  { "x": 56,  "y": 56, "w": 574, "h": 578 },
+        "right": { "x": 650, "y": 56, "w": 574, "h": 578 }
+      }
+    },
+    "two-col-asymmetric": {
+      "card_count": 2,
+      "description": "2/3 主 + 1/3 副，主信息 + 数据辅助",
+      "slots": {
+        "main":  { "x": 56,  "y": 56, "w": 776, "h": 578 },
+        "side":  { "x": 852, "y": 56, "w": 372, "h": 578 }
+      }
+    },
+    "three-col": {
+      "card_count": 3,
+      "description": "3 张等宽，三步流程/三个特性",
+      "slots": {
+        "left":   { "x": 56,  "y": 56, "w": 376, "h": 578 },
+        "middle": { "x": 452, "y": 56, "w": 376, "h": 578 },
+        "right":  { "x": 848, "y": 56, "w": 376, "h": 578 }
+      }
+    },
+    "major-minor": {
+      "card_count": 3,
+      "description": "中央大卡 + 两侧小卡，1 主信息 + 2 支撑细节",
+      "slots": {
+        "main":  { "x": 308, "y": 56,  "w": 664, "h": 578 },
+        "top":   { "x": 56,  "y": 56,  "w": 232, "h": 280 },
+        "bottom":{ "x": 56,  "y": 354, "w": 232, "h": 280 },
+        "right_top":   { "x": 992, "y": 56,  "w": 232, "h": 280 },
+        "right_bottom":{ "x": 992, "y": 354, "w": 232, "h": 280 }
+      }
+    },
+    "hero-top": {
+      "card_count": 4,
+      "description": "顶部横幅 + 下方 3 等宽，论点 + 多个论据",
+      "slots": {
+        "hero":  { "x": 56,  "y": 56,  "w": 1168, "h": 240 },
+        "col1":  { "x": 56,  "y": 316, "w": 376,  "h": 318 },
+        "col2":  { "x": 452, "y": 316, "w": 376,  "h": 318 },
+        "col3":  { "x": 848, "y": 316, "w": 376,  "h": 318 }
+      }
+    },
+    "mixed-grid": {
+      "card_count": 4,
+      "description": "自由混合，4 个不同大小卡片",
+      "slots": {
+        "tl": { "x": 56,  "y": 56,  "w": 776, "h": 280 },
+        "tr": { "x": 852, "y": 56,  "w": 372, "h": 280 },
+        "bl": { "x": 56,  "y": 356, "w": 372, "h": 278 },
+        "br": { "x": 452, "y": 356, "w": 772, "h": 278 }
+      }
+    }
+  }
+}

--- a/themes/bento-paper/slide-base.svg.j2
+++ b/themes/bento-paper/slide-base.svg.j2
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 {{ theme.viewBox.width }} {{ theme.viewBox.height }}"
+     width="{{ theme.viewBox.width }}" height="{{ theme.viewBox.height }}">
+  <defs>
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="{{ theme.colors.bg_start }}"/>
+      <stop offset="100%" stop-color="{{ theme.colors.bg_end }}"/>
+    </linearGradient>
+    <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="{{ theme.colors.accent_primary }}"/>
+      <stop offset="100%" stop-color="{{ theme.colors.accent_secondary }}"/>
+    </linearGradient>
+    <linearGradient id="accent-grad-v" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="{{ theme.colors.accent_primary }}"/>
+      <stop offset="100%" stop-color="{{ theme.colors.accent_secondary }}"/>
+    </linearGradient>
+    {%- set spot_op = (theme.effects.bg_spot_opacity if theme.effects else 0.4) | default(0.4) -%}
+    <radialGradient id="spot-1" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="{{ theme.colors.accent_primary }}" stop-opacity="{{ spot_op }}"/>
+      <stop offset="100%" stop-color="{{ theme.colors.accent_primary }}" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="spot-2" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="{{ theme.colors.accent_secondary }}" stop-opacity="{{ (spot_op * 0.75) | round(2) }}"/>
+      <stop offset="100%" stop-color="{{ theme.colors.accent_secondary }}" stop-opacity="0"/>
+    </radialGradient>
+    {%- set bg_tex = (theme.effects.bg_texture if theme.effects else 'none') | default('none') -%}
+    {%- set tex_op = (theme.effects.bg_texture_opacity if theme.effects else 0.05) | default(0.05) -%}
+    {%- set tex_sz = (theme.effects.bg_texture_size if theme.effects else 48) | default(48) -%}
+    {%- set tex_clr = (theme.effects.bg_texture_color if theme.effects else '#ffffff') | default('#ffffff') -%}
+    {%- if bg_tex == 'grid' %}
+    <pattern id="bg-texture" width="{{ tex_sz }}" height="{{ tex_sz }}" patternUnits="userSpaceOnUse">
+      <path d="M {{ tex_sz }} 0 L 0 0 0 {{ tex_sz }}" fill="none" stroke="{{ tex_clr }}" stroke-opacity="{{ tex_op }}" stroke-width="0.5"/>
+    </pattern>
+    {%- elif bg_tex == 'dots' %}
+    <pattern id="bg-texture" width="{{ tex_sz }}" height="{{ tex_sz }}" patternUnits="userSpaceOnUse">
+      <circle cx="{{ (tex_sz / 2) | int }}" cy="{{ (tex_sz / 2) | int }}" r="0.9" fill="{{ tex_clr }}" fill-opacity="{{ tex_op * 2 }}"/>
+    </pattern>
+    {%- endif %}
+  </defs>
+
+  <style type="text/css">
+    text { font-family: {{ theme.fonts.sans }}; }
+    .mono { font-family: {{ theme.fonts.mono }}; }
+    .eyebrow { font-size: {{ theme.type_scale.eyebrow }}px; fill: {{ theme.colors.accent_secondary }}; letter-spacing: 3px; font-weight: 600; font-family: {{ theme.fonts.mono }}; }
+    .h1 { font-size: {{ theme.type_scale.h1 }}px; fill: {{ theme.colors.text_primary }}; font-weight: 700; font-family: {{ theme.fonts.display }}; }
+    .h2 { font-size: {{ theme.type_scale.h2 }}px; fill: {{ theme.colors.text_primary }}; font-weight: 700; font-family: {{ theme.fonts.display }}; }
+    .h3 { font-size: {{ theme.type_scale.h3 }}px; fill: {{ theme.colors.text_primary }}; font-weight: 600; font-family: {{ theme.fonts.display }}; }
+    .h4 { font-size: {{ theme.type_scale.h4 }}px; fill: {{ theme.colors.text_primary }}; font-weight: 600; font-family: {{ theme.fonts.display }}; }
+    .body { font-size: {{ theme.type_scale.body }}px; fill: {{ theme.colors.text_secondary }}; }
+    .small { font-size: {{ theme.type_scale.small }}px; fill: {{ theme.colors.text_muted }}; }
+    .stat-huge { font-size: {{ theme.type_scale.stat_huge }}px; fill: {{ theme.colors.text_primary }}; font-weight: 800; font-family: {{ theme.fonts.display }}; }
+    .stat-unit { font-size: {{ theme.type_scale.stat_unit }}px; fill: {{ theme.colors.text_secondary }}; font-weight: 500; }
+  </style>
+
+  <!-- 背景渐变 -->
+  <rect width="{{ theme.viewBox.width }}" height="{{ theme.viewBox.height }}" fill="url(#bg-grad)"/>
+  {%- if bg_tex in ('grid', 'dots') %}
+  <!-- 纹理层 -->
+  <rect width="{{ theme.viewBox.width }}" height="{{ theme.viewBox.height }}" fill="url(#bg-texture)"/>
+  {%- endif %}
+
+  <!-- 装饰光斑（极淡，不干扰阅读） -->
+  <ellipse cx="1180" cy="80" rx="280" ry="220" fill="url(#spot-1)"/>
+  <ellipse cx="120" cy="640" rx="280" ry="200" fill="url(#spot-2)"/>
+
+  {%- if page.ghost_text %}
+  <!-- Ghost text：巨型半透明背景装饰字 -->
+  <text x="{{ theme.viewBox.width // 2 }}" y="{{ (theme.viewBox.height * 0.68) | int }}"
+        font-size="300" font-weight="800" text-anchor="middle"
+        fill="{{ theme.colors.text_primary }}" opacity="0.04"
+        font-family="{{ theme.fonts.display }}">{{ page.ghost_text }}</text>
+  {%- endif %}
+
+  <!-- layout 渲染区 -->
+  {{ content | safe }}
+
+  <!-- 页脚 -->
+  <text x="{{ theme.spacing.page_padding }}" y="{{ theme.viewBox.height - 18 }}" class="small">{{ meta.title | default('') }}</text>
+  <text x="{{ theme.viewBox.width - theme.spacing.page_padding }}" y="{{ theme.viewBox.height - 18 }}" class="small mono" text-anchor="end">{{ '%02d' | format(page.page) }} / {{ '%02d' | format(total_pages) }}</text>
+</svg>


### PR DESCRIPTION
## Summary

基于 guizang-ppt-skill 的设计理念，新增第三个主题 `bento-paper`。

### 设计
- 三级字体层级：衬线标题 (Noto Serif SC) + 非衬线正文 (Noto Sans SC) + 等宽元数据 (IBM Plex Mono)
- 温暖纸质色调：奶油底色 #F5F0E8，深墨文字 #1a1815
- 棕绿双色 accent，细点纹理，极淡光斑
- 自定义 slide-base.svg.j2 覆盖 CSS 类实现字体层级区分
- 组件和布局模板继承 bento-tech

### 文件
- `themes/bento-paper/manifest.json` — 设计令牌
- `themes/bento-paper/slide-base.svg.j2` — 字体层级 CSS

## Verification
```
ruff check   ✅
mypy         ✅
pytest -q    ✅ 60 passed
```

## Related
Closes #12