### PR TITLE
fix: 恢复 stat 窄卡单位换行后的 y 偏移

### DIFF
--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -506,7 +506,7 @@ class NativeRenderer:
                     bold=True,
                 )
             else:
-                # 窄卡单位换行，紧贴 value 下方、左对齐
+                # 窄卡单位换行；y+=4 防止与 sub_value/装饰条重叠
                 self._add_textbox(
                     slide,
                     unit,

--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -518,6 +518,7 @@ class NativeRenderer:
                     color=self.theme["colors"]["text_secondary"],
                     bold=True,
                 )
+                y += 4
 
         if data.get("sub_value"):
             sub_size = int(huge * 0.24)


### PR DESCRIPTION
codex post-merge finding: 单位换行时 y 偏移被删导致可能与装饰条重叠。加回 y+=4 最小偏移。