### PR TITLE
fix: 还原 Google Fonts 优先 + dev-flow codex 限额处理

### DIFF
--- a/examples/dify-intro/slides/01-cover.svg
+++ b/examples/dify-intro/slides/01-cover.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 
@@ -55,7 +55,7 @@
   <svg x="40" y="40"
        width="1088" height="498"
        viewBox="0 0 1088 498">
-    <text x="1068" y="482" text-anchor="end" font-size="159" font-weight="900" fill="#B8654A" opacity="0.07" letter-spacing="6" font-family="&#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif">2026 FUTURE</text><text x="0" y="18" class="eyebrow">PRODUCT INTRO · 2026 Q2</text><text x="0" y="92" font-size="56" fill="#1a1815" font-weight="700">Dify 企业介绍</text><text x="0" y="159" font-size="56" fill="#1a1815" font-weight="700">下一代 AI 应用开发平台</text><g transform="translate(0, 181)">
+    <text x="1068" y="482" text-anchor="end" font-size="159" font-weight="900" fill="#B8654A" opacity="0.07" letter-spacing="6" font-family="&#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif">2026 FUTURE</text><text x="0" y="18" class="eyebrow">PRODUCT INTRO · 2026 Q2</text><text x="0" y="92" font-size="56" fill="#1a1815" font-weight="700">Dify 企业介绍</text><text x="0" y="159" font-size="56" fill="#1a1815" font-weight="700">下一代 AI 应用开发平台</text><g transform="translate(0, 181)">
   <rect x="0" y="0" width="152" height="24" rx="12" fill="#B8654A" fill-opacity="0.22" stroke="#B8654A" stroke-opacity="0.55" stroke-width="1"/>
   <text x="76.0" y="16" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff" letter-spacing="1">PRODUCTION-READY</text>
 </g><text x="0" y="241" font-size="28" fill="#5c5548" font-weight="400">把生成式 AI 的不确定，变成产品落地的确定</text><rect x="0" y="418" width="120" height="4" fill="url(#accent-grad)" rx="2"/><text x="0" y="460" font-size="12" fill="#9c9588" letter-spacing="2">PRESENTED BY</text>

--- a/examples/dify-intro/slides/02-two-col-symmetric-demo.svg
+++ b/examples/dify-intro/slides/02-two-col-symmetric-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/03-two-col-asymmetric-demo.svg
+++ b/examples/dify-intro/slides/03-two-col-asymmetric-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/04-three-col-demo.svg
+++ b/examples/dify-intro/slides/04-three-col-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/05-major-minor-demo.svg
+++ b/examples/dify-intro/slides/05-major-minor-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/06-hero-top-demo.svg
+++ b/examples/dify-intro/slides/06-hero-top-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/07-mixed-grid-demo.svg
+++ b/examples/dify-intro/slides/07-mixed-grid-demo.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/examples/dify-intro/slides/08-end.svg
+++ b/examples/dify-intro/slides/08-end.svg
@@ -26,16 +26,16 @@
     </pattern>  </defs>
 
   <style type="text/css">
-    text { font-family: &#39;PingFang SC&#39;, &#39;Noto Sans SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
-    .mono { font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;Menlo&#39;, &#39;SF Mono&#39;, &#39;IBM Plex Mono&#39;, &#39;Courier&#39;, monospace; }
-    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
-    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    text { font-family: &#39;Noto Sans SC&#39;, &#39;PingFang SC&#39;, &#39;Microsoft YaHei&#39;, sans-serif; }
+    .mono { font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .eyebrow { font-size: 14px; fill: #D4956B; letter-spacing: 3px; font-weight: 600; font-family: &#39;IBM Plex Mono&#39;, &#39;SF Mono&#39;, &#39;JetBrains Mono&#39;, Menlo, monospace; }
+    .h1 { font-size: 56px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h2 { font-size: 42px; fill: #1a1815; font-weight: 700; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h3 { font-size: 28px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
+    .h4 { font-size: 20px; fill: #1a1815; font-weight: 600; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .body { font-size: 17px; fill: #5c5548; }
     .small { font-size: 13px; fill: #9c9588; }
-    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Songti SC&#39;, &#39;Noto Serif SC&#39;, &#39;STKaiti&#39;, &#39;Times New Roman&#39;, serif; }
+    .stat-huge { font-size: 100px; fill: #1a1815; font-weight: 800; font-family: &#39;Noto Serif SC&#39;, &#39;Playfair Display&#39;, &#39;Songti SC&#39;, &#39;Times New Roman&#39;, serif; }
     .stat-unit { font-size: 26px; fill: #5c5548; font-weight: 500; }
   </style>
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -171,7 +171,7 @@ class TestBentoPaper:
         manifest, _ = load_theme("bento-paper")
         assert manifest["name"] == "bento-paper"
         assert manifest["effects"]["bg_texture"] == "dots"
-        assert "Songti SC" in manifest["fonts"]["display"]
+        assert "Noto Serif SC" in manifest["fonts"]["display"]
 
     def test_render_example(self):
         ws = Path("examples/dify-intro")
@@ -190,7 +190,7 @@ class TestBentoPaper:
             "cards": [{"slot": "main", "component": "card-hero", "data": {"eyebrow": "MAGAZINE", "title": "标题", "subtitle": "副标题"}}],
         }
         svg = render_one_page(env, manifest, page, total_pages=1, meta={})
-        assert "Songti SC" in svg
-        assert "Menlo" in svg
+        assert "Noto Serif SC" in svg
+        assert "IBM Plex Mono" in svg
         assert "#F5F0E8" in svg
         assert "#B8654A" in svg

--- a/themes/bento-paper/manifest.json
+++ b/themes/bento-paper/manifest.json
@@ -7,9 +7,9 @@
     "height": 720
   },
   "fonts": {
-    "sans": "'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif",
-    "mono": "'Menlo', 'SF Mono', 'IBM Plex Mono', 'Courier', monospace",
-    "display": "'Songti SC', 'Noto Serif SC', 'STKaiti', 'Times New Roman', serif"
+    "sans": "'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif",
+    "mono": "'IBM Plex Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace",
+    "display": "'Noto Serif SC', 'Playfair Display', 'Songti SC', 'Times New Roman', serif"
   },
   "type_scale": {
     "eyebrow": 14,


### PR DESCRIPTION
1. bento-paper 字体栈还原 Google Fonts 首位（PR #22 错误降级）2. dev-flow Phase 8 增加 codex 限额→本地审查切换。Keynote 用户推荐 deck-svg.pptx。