### PR TITLE
chore: README 三主题 + render 错误路径测试

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Claude Code skill that turns a topic or document into a 16:9 SVG slide deck in
 - **7 阶段流水线**：needs（反问） → research → outline（金字塔原理） → planning → fetch → design → review → export
 - **6 种 Bento 布局** + **9 种卡片组件**：single-focus / two-col-symmetric / two-col-asymmetric / three-col / major-minor / hero-top / mixed-grid 任选；卡内可放 card-hero / card-stat / **card-stack**（多数据叠加）/ card-list（highlight 焦点项）/ card-quote / card-text / card-image / **card-compare**（多列对比表）/ chart-bar
 - **跨组件装饰元素**：胶囊 badges / 三栏 metadata / 半透明装饰大字 / **ghost_text 背景装饰字** / 网格背景纹理
-- **双主题**：`bento-tech`（深色科技风）/ `bento-light`（浅色商务风），主题继承机制让新主题只需一个 manifest.json
+- **三主题**：`bento-paper`（暖纸杂志风，默认）/ `bento-tech`（深色科技风）/ `bento-light`（浅色商务风），主题继承机制让新主题只需一个 manifest.json
 - **底层 SVG**（viewBox `0 0 1280 720`），双 PPTX 导出路径：
   - **Native**（默认）：`scripts/native_render.py` 用 python-pptx 直接画原生 shape，**100% 可编辑**（单击文字直接改、无需"转换为形状"）。视觉商务平面（无渐变 / 光斑）
   - **SVG**（备选 `--format pptx-svg`）：通过 `asvg:svgBlip` OOXML 注入到 pptx，PowerPoint 2019+/Office 365 显示完美矢量但默认是 picture 对象
@@ -155,7 +155,8 @@ ppt-agent/
 │       ├── nanobanana.py          # Gemini Image (stub)
 │       └── unsplash.py            # Unsplash (stub)
 ├── themes/
-│   ├── bento-tech/                # 深色科技风（默认）：渐变光斑 + 玻璃拟态卡片
+│   ├── bento-paper/               # 暖纸杂志风（默认）：衬线标题 + 点状纹理
+│   ├── bento-tech/                # 深色科技风：渐变光斑 + 玻璃拟态卡片
 │   │   ├── manifest.json          # 设计 token + layout 槽位元数据
 │   │   ├── slide-base.svg.j2      # 1280×720 容器（背景 / defs / ghost_text / 页脚）
 │   │   ├── layouts/_base.svg.j2   # 数据驱动通用 layout

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -90,8 +90,14 @@ def _embed_fonts(pptx_path: Path, fonts: dict[str, Path]) -> None:
                 next_rid += 1
 
             # Update zip entries
-            out.writestr("ppt/presentation.xml", etree.tostring(pres_xml, xml_declaration=True, encoding="UTF-8", standalone=True))
-            out.writestr("ppt/_rels/presentation.xml.rels", etree.tostring(rels_xml, xml_declaration=True, encoding="UTF-8", standalone=True))
+            out.writestr(
+                "ppt/presentation.xml",
+                etree.tostring(pres_xml, xml_declaration=True, encoding="UTF-8", standalone=True),
+            )
+            out.writestr(
+                "ppt/_rels/presentation.xml.rels",
+                etree.tostring(rels_xml, xml_declaration=True, encoding="UTF-8", standalone=True),
+            )
 
     # Replace original
     pptx_path.write_bytes(buf.getvalue())

--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -133,8 +133,10 @@ class NativeRenderer:
         overflow = Emu(91440)
         bg = slide.shapes.add_shape(
             MSO_SHAPE.RECTANGLE,
-            -overflow, -overflow,
-            Emu(int(sw)) + overflow * 2, Emu(int(shh)) + overflow * 2,
+            -overflow,
+            -overflow,
+            Emu(int(sw)) + overflow * 2,
+            Emu(int(shh)) + overflow * 2,
         )
         bg.line.fill.background()
         gf = etree.SubElement(bg._element.spPr, f"{{{A_NS}}}gradFill")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -187,11 +187,38 @@ class TestBentoPaper:
         page = {
             "page": 1,
             "layout": "single-focus",
-            "cards": [{"slot": "main", "component": "card-hero", "data": {"eyebrow": "MAGAZINE", "title": "标题", "subtitle": "副标题"}}],
+            "cards": [
+                {
+                    "slot": "main",
+                    "component": "card-hero",
+                    "data": {"eyebrow": "MAGAZINE", "title": "标题", "subtitle": "副标题"},
+                }
+            ],
         }
         svg = render_one_page(env, manifest, page, total_pages=1, meta={})
         # 验证 Google Fonts 排在 font-family 首位：CSS 类必须以该字体开头
         assert "font-family: &#39;Noto Serif SC&#39;" in svg  # .h1 等标题类
         assert "font-family: &#39;IBM Plex Mono&#39;" in svg  # .mono / .eyebrow 类
-        assert "#F5F0E8" in svg
-        assert "#B8654A" in svg
+
+
+class TestRenderErrorPaths:
+    def test_render_all_empty_pages(self):
+        import tempfile
+
+        import pytest
+        from render import render_all
+
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path
+
+            ws = Path(tmp)
+            (ws / "layout.json").write_text('{"pages": []}', encoding="utf-8")
+            with pytest.raises(SystemExit):
+                render_all(ws)
+
+    def test_render_page_out_of_range(self):
+        import pytest
+        from render import render_page
+
+        with pytest.raises(SystemExit):
+            render_page(Path("examples/dify-intro"), 99)


### PR DESCRIPTION
62 tests. README 双主题→三主题, bento-paper 默认, render error paths。