### PR TITLE
fix: OOXML 元素排序 — 修复 Windows PowerPoint 修复提示 + 样式丢失

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -60,7 +60,17 @@ def _embed_fonts(pptx_path: Path, fonts: dict[str, Path]) -> None:
 
         efl = pres_xml.find(f"{{{P_NS}}}embeddedFontLst")
         if efl is None:
-            efl = etree.SubElement(pres_xml, f"{{{P_NS}}}embeddedFontLst")
+            # OOXML 要求 embeddedFontLst 在 defaultTextStyle/extLst 之前
+            insert_after = None
+            for child in pres_xml:
+                if child.tag in (f"{{{P_NS}}}defaultTextStyle", f"{{{P_NS}}}extLst"):
+                    insert_after = child
+                    break
+            efl = etree.Element(f"{{{P_NS}}}embeddedFontLst")
+            if insert_after is not None:
+                insert_after.addprevious(efl)
+            else:
+                pres_xml.append(efl)
 
             # Count existing rIds
             existing_rids = {r.get("Id", "") for r in rels_xml}

--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -139,7 +139,13 @@ class NativeRenderer:
             Emu(int(shh)) + overflow * 2,
         )
         bg.line.fill.background()
-        gf = etree.SubElement(bg._element.spPr, f"{{{A_NS}}}gradFill")
+        # gradFill 必须在 ln 之前（OOXML spPr 子元素顺序）
+        ln = bg._element.spPr.find(f"{{{A_NS}}}ln")
+        gf = etree.Element(f"{{{A_NS}}}gradFill")
+        if ln is not None:
+            ln.addprevious(gf)
+        else:
+            bg._element.spPr.append(gf)
         gsl = etree.SubElement(gf, f"{{{A_NS}}}gsLst")
         for pos, clr in [("0", self.theme["colors"]["bg_start"]), ("100000", self.theme["colors"]["bg_end"])]:
             gs = etree.SubElement(gsl, f"{{{A_NS}}}gs")


### PR DESCRIPTION
embeddedFontLst 和 gradFill 元素位置违反 OOXML 顺序规范，导致 Windows PowerPoint 提示修复并丢掉样式。