### PR TITLE
fix: 字体嵌入 TTF 验证 + 排除损坏下载（根因修复）

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -141,8 +141,8 @@ def to_pptx(ws: Path) -> dict:
         if not path.exists():
             continue
         header = path.read_bytes()[:4]
-        # 验证 TTF/OTF magic bytes，排除 HTML 等无效内容
-        if header[:1] == b"\x00" or header == b"OTTO":
+        # 验证 TTF/OTF sfnt 签名: TrueType=0x00010000, OpenType='OTTO'
+        if header == b"\x00\x01\x00\x00" or header == b"OTTO":
             available[name] = path
         else:
             print(f"  [warn] {path.name} 不是有效字体文件，跳过嵌入")

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -134,13 +134,18 @@ def to_pptx(ws: Path) -> dict:
 
     out_path = render_pptx(ws)
 
-    # Embed fonts if available
-    font_map = {
-        "Noto Serif SC": Path("/tmp/NotoSerifSC.ttf"),
-        "Noto Sans SC": Path("/tmp/NotoSansSC.ttf"),
-        "IBM Plex Mono": Path("/tmp/IBMPlexMono.ttf"),
-    }
-    available = {k: v for k, v in font_map.items() if v.exists()}
+    # Embed fonts if available（仅嵌 IBM Plex Mono；CJK 字体太大，靠系统字体栈）
+    font_map = {"IBM Plex Mono": Path("/tmp/IBMPlexMono.ttf")}
+    available = {}
+    for name, path in font_map.items():
+        if not path.exists():
+            continue
+        header = path.read_bytes()[:4]
+        # 验证 TTF/OTF magic bytes，排除 HTML 等无效内容
+        if header[:1] == b"\x00" or header == b"OTTO":
+            available[name] = path
+        else:
+            print(f"  [warn] {path.name} 不是有效字体文件，跳过嵌入")
     if available:
         _embed_fonts(out_path, available)
         print(f"  [embed] {len(available)} fonts embedded: {', '.join(available)}")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -196,8 +196,8 @@ class TestBentoPaper:
             ],
         }
         svg = render_one_page(env, manifest, page, total_pages=1, meta={})
-        # 验证 Google Fonts 排在 font-family 首位：CSS 类必须以该字体开头
-        assert "font-family: &#39;Noto Serif SC&#39;" in svg  # .h1 等标题类
+        # 验证标题用衬线 (Serif) 字体、eyebrow 用等宽 (Mono) 字体
+        assert "font-family: &#39;Songti SC&#39;" in svg  # .h1 等标题类，系统衬线体
         assert "font-family: &#39;IBM Plex Mono&#39;" in svg  # .mono / .eyebrow 类
 
 

--- a/themes/bento-paper/manifest.json
+++ b/themes/bento-paper/manifest.json
@@ -7,9 +7,9 @@
     "height": 720
   },
   "fonts": {
-    "sans": "'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif",
+    "sans": "'PingFang SC', 'Noto Sans SC', 'Microsoft YaHei', sans-serif",
     "mono": "'IBM Plex Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace",
-    "display": "'Noto Serif SC', 'Playfair Display', 'Songti SC', 'Times New Roman', serif"
+    "display": "'Songti SC', 'Noto Serif SC', 'STKaiti', 'Times New Roman', serif"
   },
   "type_scale": {
     "eyebrow": 14,


### PR DESCRIPTION
codex 彻查发现 /tmp/IBMPlexMono.ttf 是 HTML 不是字体——GitHub 下载失败。修复：TTF header 验证 + 仅嵌 IBM Plex Mono(135KB) + 字体栈系统优先。