### PR TITLE
fix: 移除字体嵌入 — raw TTF 违反 OOXML obfuscated font 规范

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -134,21 +134,8 @@ def to_pptx(ws: Path) -> dict:
 
     out_path = render_pptx(ws)
 
-    # Embed fonts if available（仅嵌 IBM Plex Mono；CJK 字体太大，靠系统字体栈）
-    font_map = {"IBM Plex Mono": Path("/tmp/IBMPlexMono.ttf")}
-    available = {}
-    for name, path in font_map.items():
-        if not path.exists():
-            continue
-        header = path.read_bytes()[:4]
-        # 验证 TTF/OTF sfnt 签名: TrueType=0x00010000, OpenType='OTTO'
-        if header == b"\x00\x01\x00\x00" or header == b"OTTO":
-            available[name] = path
-        else:
-            print(f"  [warn] {path.name} 不是有效字体文件，跳过嵌入")
-    if available:
-        _embed_fonts(out_path, available)
-        print(f"  [embed] {len(available)} fonts embedded: {', '.join(available)}")
+    # 字体嵌入已移除：OOXML 要求嵌入字体做 GUID XOR 混淆，
+    # 且 Keynote 不支持 OOXML 内嵌字体。字体栈已包含系统降级。
 
     return {"output": str(out_path)}
 


### PR DESCRIPTION
OOXML 内嵌字体要求 GUID XOR 混淆，直接塞 raw TTF 导致 Windows PowerPoint 检测到无效部件并触发修复。移除字体嵌入，字体栈已包含系统降级。