### PR TITLE
fix: native deco_text 使用 display 衬线字体

### DIFF
--- a/scripts/native_render.py
+++ b/scripts/native_render.py
@@ -1474,6 +1474,7 @@ class NativeRenderer:
                 font_size=dt_size,
                 color=self.theme["colors"]["accent_primary"],
                 bold=True,
+                font_name=self._first_font("display"),
                 align="right",
                 transparency=0.93,
                 letter_spacing=600,


### PR DESCRIPTION
1-line fix: card-hero deco_text 添加 font_name=display 匹配 SVG 输出